### PR TITLE
Add editor funcionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "hdr10plus_tool"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -600,6 +600,7 @@ dependencies = [
  "indicatif",
  "plotters",
  "predicates",
+ "serde",
  "serde_json",
  "thiserror",
 ]
@@ -1050,18 +1051,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1101,9 +1102,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "hdr10plus_tool"
-version = "1.7.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdr10plus_tool"
-version = "1.6.1"
+version = "1.7.0"
 authors = ["quietvoid"]
 edition = "2021"
 rust-version = "1.79.0"
@@ -17,6 +17,7 @@ indicatif = "0.17.8"
 anyhow = "1.0.88"
 thiserror = "1.0.63"
 plotters = { version = "0.3.7", default-features = false, features = ["bitmap_backend", "bitmap_encoder", "all_series"] }
+serde = { version = "1.0.215", features = ["derive"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdr10plus_tool"
-version = "1.7.0"
+version = "1.6.1"
 authors = ["quietvoid"]
 edition = "2021"
 rust-version = "1.79.0"

--- a/README.md
+++ b/README.md
@@ -104,11 +104,6 @@ Options that apply to the commands:
                 // Number of frames to duplicate
                 "length": int
             }
-        ],
-        
-        // Set the scene cut for specific frame index
-        "scene_cuts": [
-		    0, 1000, etc
         ]
     }
     ```

--- a/README.md
+++ b/README.md
@@ -81,6 +81,43 @@ Options that apply to the commands:
     hdr10plus_tool plot metadata.json -t "HDR10+ plot" -o hdr10plus_plot.png
     ```
 &nbsp;
+* ### **editor**
+    Allow adding and removing frames and scenecut
+    
+    **edits.json**
+    The editor expects a JSON config like the example below:
+    ```json5
+    {
+        // List of frames or frame ranges to remove (inclusive)
+        // Frames are removed before the duplicate passes
+        "remove": [
+            "0-39"
+        ],
+
+        // List of duplicate operations
+        "duplicate": [
+            {
+                // Frame to use as metadata source
+                "source": int,
+                // Index at which the duplicated frames are added (inclusive)
+                "offset": int,
+                // Number of frames to duplicate
+                "length": int
+            }
+        ],
+        
+        // Set the scene cut for specific frame index
+        "scene_cuts": [
+		    0, 1000, etc
+        ]
+    }
+    ```
+    
+    **Example**
+    ```console
+    hdr10plus_tool editor metadata.json -j edits.json -o metadata_modified.json
+    ```
+&nbsp;
 
 ### Wrong metadata order workaround
 The `skip-reorder` option should only be used as a workaround for misauthored HEVC files.  

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Options that apply to the commands:
     ```
 &nbsp;
 * ### **editor**
-    Allow adding and removing frames and scenecut
+    Allow adding and removing frames
     
     **edits.json**
     The editor expects a JSON config like the example below:

--- a/hdr10plus/src/metadata_json.rs
+++ b/hdr10plus/src/metadata_json.rs
@@ -33,7 +33,7 @@ pub struct JsonInfo {
     pub version: String,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct Hdr10PlusJsonMetadata {
     pub bezier_curve_data: Option<BezierCurveData>,
@@ -59,7 +59,7 @@ pub struct ToolInfo {
     pub version: String,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct BezierCurveData {
     pub anchors: Vec<u16>,
@@ -67,7 +67,7 @@ pub struct BezierCurveData {
     pub knee_point_y: u16,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct LuminanceParameters {
     #[serde(rename = "AverageRGB")]
@@ -77,7 +77,7 @@ pub struct LuminanceParameters {
     pub max_scl: Vec<u32>,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct LuminanceDistributions {
     pub distribution_index: Vec<u8>,

--- a/hdr10plus/src/metadata_json.rs
+++ b/hdr10plus/src/metadata_json.rs
@@ -33,7 +33,7 @@ pub struct JsonInfo {
     pub version: String,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct Hdr10PlusJsonMetadata {
     pub bezier_curve_data: Option<BezierCurveData>,
@@ -59,7 +59,7 @@ pub struct ToolInfo {
     pub version: String,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct BezierCurveData {
     pub anchors: Vec<u16>,
@@ -67,7 +67,7 @@ pub struct BezierCurveData {
     pub knee_point_y: u16,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct LuminanceParameters {
     #[serde(rename = "AverageRGB")]
@@ -77,7 +77,7 @@ pub struct LuminanceParameters {
     pub max_scl: Vec<u32>,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct LuminanceDistributions {
     pub distribution_index: Vec<u8>,

--- a/src/commands/editor.rs
+++ b/src/commands/editor.rs
@@ -1,13 +1,12 @@
 use std::fs::File;
-use std::path::Path;
 use std::io::{stdout, BufWriter, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Result, ensure};
+use anyhow::{bail, ensure, Result};
 use serde::{Deserialize, Serialize};
 
-use hdr10plus::metadata_json::{generate_json, MetadataJsonRoot};
 use hdr10plus::metadata::Hdr10PlusMetadata;
+use hdr10plus::metadata_json::{generate_json, MetadataJsonRoot};
 
 use crate::commands::EditorArgs;
 
@@ -41,7 +40,7 @@ pub struct DuplicateMetadata {
     length: usize,
 }
 
-impl Editor{
+impl Editor {
     pub fn edit(args: EditorArgs) -> Result<()> {
         let EditorArgs {
             input,
@@ -50,9 +49,8 @@ impl Editor{
             json_out,
         } = args;
 
-
         let input = input_from_either("editor", input, input_pos)?;
-        
+
         let out_path = if let Some(out_path) = json_out {
             out_path
         } else {
@@ -62,7 +60,7 @@ impl Editor{
                 "_modified.json"
             ))
         };
-        
+
         println!("Parsing JSON file...");
         let metadata_json_root = MetadataJsonRoot::from_file(&input)?;
         let metadata_list: Vec<Hdr10PlusMetadata> = metadata_json_root
@@ -100,18 +98,16 @@ impl Editor{
         println!("Done.");
 
         writer.flush()?;
-        
+
         Ok(())
     }
 }
-
-
 
 impl EditConfig {
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
         let json_file = File::open(path)?;
         let mut config: EditConfig = serde_json::from_reader(&json_file)?;
-        
+
         if let Some(to_duplicate) = config.duplicate.as_mut() {
             to_duplicate.sort_by_key(|meta| meta.offset);
             to_duplicate.reverse();
@@ -125,7 +121,6 @@ impl EditConfig {
         if let Some(ranges) = &self.remove {
             self.remove_frames(ranges, metadata)?;
         }
-
 
         if let Some(to_duplicate) = &self.duplicate {
             self.duplicate_metadata(to_duplicate, metadata)?;
@@ -158,7 +153,11 @@ impl EditConfig {
         }
     }
 
-    fn remove_frames(&self, ranges: &[String], metadata: &mut Vec<Hdr10PlusMetadata>) -> Result<()> {
+    fn remove_frames(
+        &self,
+        ranges: &[String],
+        metadata: &mut Vec<Hdr10PlusMetadata>,
+    ) -> Result<()> {
         let mut amount = 0;
 
         for range in ranges {
@@ -167,7 +166,7 @@ impl EditConfig {
                 ensure!(end < metadata.len(), "invalid end range {}", end);
 
                 amount += end - start + 1;
-                for _ in 0..amount{
+                for _ in 0..amount {
                     metadata.remove(start);
                 }
             } else if let Ok(index) = range.parse::<usize>() {
@@ -193,7 +192,10 @@ impl EditConfig {
         to_duplicate: &[DuplicateMetadata],
         metadata: &mut Vec<Hdr10PlusMetadata>,
     ) -> Result<()> {
-        println!("Duplicating metadata. Initial metadata len {}", metadata.len());
+        println!(
+            "Duplicating metadata. Initial metadata len {}",
+            metadata.len()
+        );
 
         for meta in to_duplicate {
             ensure!(

--- a/src/commands/editor.rs
+++ b/src/commands/editor.rs
@@ -1,0 +1,257 @@
+use std::collections::HashSet;
+use std::fs::File;
+use std::path::Path;
+use std::io::{stdout, BufWriter, Write};
+use std::path::PathBuf;
+
+use anyhow::{bail, Result, ensure};
+use serde::{Deserialize, Serialize};
+
+use hdr10plus::metadata_json::{Hdr10PlusJsonMetadata, MetadataJsonRoot};
+
+use crate::commands::EditorArgs;
+
+pub const TOOL_NAME: &str = env!("CARGO_PKG_NAME");
+pub const TOOL_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+use super::input_from_either;
+
+pub struct Editor {
+    edits_json: PathBuf,
+    json_out: PathBuf,
+
+    metadata_root: MetadataJsonRoot,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct EditConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remove: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    duplicate: Option<Vec<DuplicateMetadata>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scene_cuts: Option<Vec<usize>>,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct DuplicateMetadata {
+    source: usize,
+    offset: usize,
+    length: usize,
+}
+
+impl Editor{
+    pub fn edit(args: EditorArgs) -> Result<()> {
+        let EditorArgs {
+            input,
+            input_pos,
+            edits_json,
+            json_out,
+        } = args;
+
+
+        let input = input_from_either("editor", input, input_pos)?;
+        
+        let out_path = if let Some(out_path) = json_out {
+            out_path
+        } else {
+            PathBuf::from(format!(
+                "{}{}",
+                input.file_stem().unwrap().to_str().unwrap(),
+                "_modified.json"
+            ))
+        };
+        
+        println!("Parsing JSON file...");
+        let metadata_root = MetadataJsonRoot::from_file(&input)?;
+
+        let mut editor = Editor {
+            edits_json,
+            json_out: out_path,
+
+            metadata_root,
+        };
+
+        let config: EditConfig = EditConfig::from_path(&editor.edits_json)?;
+
+        println!("EditConfig {}", serde_json::to_string_pretty(&config)?);
+
+        config.execute(&mut editor.metadata_root)?;
+
+        let save_file = File::create(editor.json_out).expect("Can't create file");
+        let mut writer = BufWriter::with_capacity(10_000_000, save_file);
+
+        print!("Generating and writing metadata to new JSON file... ");
+        stdout().flush().ok();
+
+        editor.metadata_root.tool_info.tool = TOOL_NAME.to_string();
+        editor.metadata_root.tool_info.version = TOOL_VERSION.to_string();
+
+        writeln!(writer, "{}", serde_json::to_string_pretty(&editor.metadata_root)?)?;
+
+        println!("Done.");
+
+        writer.flush()?;
+        
+        Ok(())
+    }
+}
+
+
+
+impl EditConfig {
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let json_file = File::open(path)?;
+        let mut config: EditConfig = serde_json::from_reader(&json_file)?;
+        
+        if let Some(to_duplicate) = config.duplicate.as_mut() {
+            to_duplicate.sort_by_key(|meta| meta.offset);
+            to_duplicate.reverse();
+        }
+
+        Ok(config)
+    }
+
+    fn execute(self, metadata: &mut MetadataJsonRoot) -> Result<()> {
+        let mut do_renumber: bool = false;
+
+        // Drop metadata frames
+        if let Some(ranges) = &self.remove {
+            self.remove_frames(ranges, &mut metadata.scene_info)?;
+
+            do_renumber = true;
+        }
+
+
+        if let Some(to_duplicate) = &self.duplicate {
+            self.duplicate_metadata(to_duplicate, &mut metadata.scene_info)?;
+
+            do_renumber = true;
+        }
+
+        let scene_cuts: HashSet<usize> = self.scene_cuts.unwrap_or(Vec::new()).into_iter().collect();
+
+        if !scene_cuts.is_empty() || do_renumber {
+            let mut new_scene_first_frame_index: Vec<usize> = Vec::new();
+            let mut new_scene_frame_numbers: Vec<usize> = Vec::new();
+
+            let mut curr_scene_id: usize = metadata.scene_info[0].scene_id;
+            let mut new_scene_id: usize = 0;
+            let mut new_scene_frame_index: usize = 0;
+
+            new_scene_first_frame_index.push(0);
+
+            for idx in 0..metadata.scene_info.len(){
+                metadata.scene_info[idx].sequence_frame_index = idx;
+
+                if curr_scene_id != metadata.scene_info[idx].scene_id || scene_cuts.contains(&idx){
+                    if curr_scene_id != metadata.scene_info[idx].scene_id {
+                        curr_scene_id = metadata.scene_info[idx].scene_id;
+                    }
+
+                    new_scene_first_frame_index.push(idx);
+                    new_scene_frame_numbers.push(new_scene_frame_index);
+
+                    new_scene_id += 1;
+                    new_scene_frame_index = 0;
+                }
+                metadata.scene_info[idx].scene_id = new_scene_id;
+                metadata.scene_info[idx].scene_frame_index = new_scene_frame_index;
+                new_scene_frame_index += 1;
+            }
+            new_scene_frame_numbers.push(new_scene_frame_index);
+
+
+            metadata.scene_info_summary.scene_first_frame_index = new_scene_first_frame_index;
+            metadata.scene_info_summary.scene_frame_numbers = new_scene_frame_numbers;
+        }
+
+        Ok(())
+    }
+
+    fn range_string_to_tuple(range: &str) -> Result<(usize, usize)> {
+        let mut result = (0, 0);
+
+        if range.contains('-') {
+            let mut split = range.split('-');
+
+            if let Some(first) = split.next() {
+                if let Ok(first_num) = first.parse() {
+                    result.0 = first_num;
+                }
+            }
+
+            if let Some(second) = split.next() {
+                if let Ok(second_num) = second.parse() {
+                    result.1 = second_num;
+                }
+            }
+
+            Ok(result)
+        } else {
+            bail!("Invalid edit range")
+        }
+    }
+
+    fn remove_frames(&self, ranges: &[String], metadata: &mut Vec<Hdr10PlusJsonMetadata>) -> Result<()> {
+        let mut amount = 0;
+
+        for range in ranges {
+            if range.contains('-') {
+                let (start, end) = EditConfig::range_string_to_tuple(range)?;
+                ensure!(end < metadata.len(), "invalid end range {}", end);
+
+                amount += end - start + 1;
+                for _ in 0..amount{
+                    metadata.remove(start);
+                }
+            } else if let Ok(index) = range.parse::<usize>() {
+                ensure!(
+                    index < metadata.len(),
+                    "invalid frame index to remove {}",
+                    index
+                );
+
+                metadata.remove(index);
+
+                amount += 1;
+            }
+        }
+
+        println!("Removed {amount} metadata frames.");
+
+        Ok(())
+    }
+
+    fn duplicate_metadata(
+        &self,
+        to_duplicate: &[DuplicateMetadata],
+        metadata: &mut Vec<Hdr10PlusJsonMetadata>,
+    ) -> Result<()> {
+        println!("Duplicating metadata. Initial metadata len {}", metadata.len());
+
+        for meta in to_duplicate {
+            ensure!(
+                meta.source < metadata.len() && meta.offset <= metadata.len(),
+                "invalid duplicate: {:?}",
+                meta
+            );
+
+            let mut source = metadata[meta.source].clone();
+            //Assume that the copied metadata are in the same scene cut of the at the frame at offset position 
+            source.scene_id = metadata[meta.offset].scene_id;
+            metadata.splice(
+                meta.offset..meta.offset,
+                std::iter::repeat(source).take(meta.length),
+            );
+        }
+
+        println!("Final metadata length: {}", metadata.len());
+
+        Ok(())
+    }
+}

--- a/src/commands/editor.rs
+++ b/src/commands/editor.rs
@@ -24,7 +24,7 @@ pub struct Editor {
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
-#[serde(deny_unknown_fields)]
+#[serde()]
 pub struct EditConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     remove: Option<Vec<String>>,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,11 +6,11 @@ use hdr10plus::metadata::PeakBrightnessSource;
 
 use crate::CliOptions;
 
+pub mod editor;
 pub mod extract;
 pub mod inject;
 pub mod plot;
 pub mod remove;
-pub mod editor;
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ArgPeakBrightnessSource {
@@ -202,7 +202,6 @@ pub struct PlotArgs {
     )]
     pub peak_source: ArgPeakBrightnessSource,
 }
-
 
 #[derive(Args, Debug)]
 pub struct EditorArgs {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod extract;
 pub mod inject;
 pub mod plot;
 pub mod remove;
+pub mod editor;
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ArgPeakBrightnessSource {
@@ -39,6 +40,9 @@ pub enum Command {
 
     #[command(about = "Plot the HDR10+ dynamic brightness metadata")]
     Plot(PlotArgs),
+
+    #[command(about = "Edit the HDR10+ metadata")]
+    Editor(EditorArgs),
 }
 
 #[derive(Args, Debug)]
@@ -197,6 +201,47 @@ pub struct PlotArgs {
         default_value = "histogram"
     )]
     pub peak_source: ArgPeakBrightnessSource,
+}
+
+
+#[derive(Args, Debug)]
+pub struct EditorArgs {
+    #[arg(
+        id = "input",
+        help = "Sets the input JSON file to use",
+        long,
+        short = 'i',
+        conflicts_with = "input_pos",
+        required_unless_present = "input_pos",
+        value_hint = ValueHint::FilePath,
+    )]
+    pub input: Option<PathBuf>,
+
+    #[arg(
+        id = "input_pos",
+        help = "Sets the input JSON file to use (positional)",
+        conflicts_with = "input",
+        required_unless_present = "input",
+        value_hint = ValueHint::FilePath
+    )]
+    pub input_pos: Option<PathBuf>,
+
+    #[arg(
+        id = "json",
+        long,
+        short = 'j',
+        help = "Sets the edit JSON file to use",
+        value_hint = ValueHint::FilePath
+    )]
+    pub edits_json: PathBuf,
+
+    #[arg(
+        long,
+        short = 'o',
+        help = "Modified JSON output file location",
+        value_hint = ValueHint::FilePath
+    )]
+    pub json_out: Option<PathBuf>,
 }
 
 pub fn input_from_either(cmd: &str, in1: Option<PathBuf>, in2: Option<PathBuf>) -> Result<PathBuf> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use commands::extract::Extractor;
 use commands::inject::Injector;
 use commands::plot::Plotter;
 use commands::remove::Remover;
+use commands::editor::Editor;
 use commands::Command;
 
 use crate::core::ParserError;
@@ -45,6 +46,7 @@ fn main() -> Result<()> {
         Command::Inject(args) => Injector::inject_json(args, cli_options),
         Command::Remove(args) => Remover::remove_sei(args, cli_options),
         Command::Plot(args) => Plotter::plot(args),
+        Command::Editor(args) => Editor::edit(args),
     };
 
     let actually_errored = if let Err(e) = &res {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,11 @@ mod commands;
 mod core;
 mod utils;
 
+use commands::editor::Editor;
 use commands::extract::Extractor;
 use commands::inject::Injector;
 use commands::plot::Plotter;
 use commands::remove::Remover;
-use commands::editor::Editor;
 use commands::Command;
 
 use crate::core::ParserError;


### PR DESCRIPTION
This implement a simple editor functionality capable of removing frame, duplicating them and setting scene changes, most of the syntax was inherited from dovi_tool's editor

First time writing rust code, I know that the code is more C(arbon) then Iron Oxide, most of that was written copying code from other part of the codebase and dovi_tool.

I've made some tests and seems to work as expected, at least as far as I'm able to check due to size of the json files